### PR TITLE
MODRS-16 - Remote storage backend requests do not work

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -164,13 +164,13 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 512673984,
+        "Memory": 712673984,
         "PortBindings": { "8081/tcp": [ { "HostPort": "%p" } ] }
       }
     },
     "env": [
       { "name": "JAVA_OPTIONS",
-        "value": "-Xmx256m -XX:MaxRAMPercentage=75.0"
+        "value": "-XX:MaxRAMPercentage=75.0"
       },
       { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },


### PR DESCRIPTION
Additional PR to [PR#16](https://github.com/folio-org/mod-remote-storage/pull/16) with ModuleDescriptor changes.