### PR TITLE
MODRS-20 - Accessions API doesn't work with compound query

### DIFF
--- a/src/main/java/org/folio/rs/service/AccessionQueueService.java
+++ b/src/main/java/org/folio/rs/service/AccessionQueueService.java
@@ -151,6 +151,9 @@ public class AccessionQueueService {
       if (Boolean.TRUE.equals(filterData.getIsPresented())) {
         predicates.add(builder.isNotNull(record.get(ACCESSIONED_DATE_TIME)));
       }
+      if (Boolean.FALSE.equals(filterData.getIsPresented())) {
+        predicates.add(builder.isNull(record.get(ACCESSIONED_DATE_TIME)));
+      }
       if (Objects.nonNull(filterData.getStorageId())) {
         predicates.add(builder.equal(record.get(REMOTE_STORAGE_ID), stringToUUIDSafe(filterData.getStorageId())));
       }

--- a/src/main/java/org/folio/rs/service/RetrievalQueueService.java
+++ b/src/main/java/org/folio/rs/service/RetrievalQueueService.java
@@ -66,6 +66,9 @@ public class RetrievalQueueService {
       if (Boolean.TRUE.equals(filterData.getIsPresented())) {
         predicates.add(builder.isNotNull(record.get(RETRIEVED_DATE_TIME)));
       }
+      if (Boolean.FALSE.equals(filterData.getIsPresented())) {
+        predicates.add(builder.isNull(record.get(RETRIEVED_DATE_TIME)));
+      }
       if (Objects.nonNull(filterData.getStorageId())) {
         predicates.add(builder.equal(record.get(REMOTE_STORAGE_ID), stringToUUIDSafe(filterData.getStorageId())));
       }

--- a/src/test/java/org/folio/rs/service/AccessionQueueServiceTest.java
+++ b/src/test/java/org/folio/rs/service/AccessionQueueServiceTest.java
@@ -5,6 +5,7 @@ import static org.folio.rs.util.Utils.randomIdAsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDateTime;
@@ -127,11 +128,25 @@ public class AccessionQueueServiceTest extends TestBase {
     accessionQueueRecord.setAccessionedDateTime(LocalDateTime.now());
     accessionQueueRepository.save(accessionQueueRecord);
 
-    ResponseEntity<AccessionQueues> responseEntity = get(formattedAccessionUrl + "?accessioned=true", AccessionQueues.class);
+    ResponseEntity<AccessionQueues> allAccessionQueueRecords = get(formattedAccessionUrl, AccessionQueues.class);
 
-    assertThat(Objects.requireNonNull(responseEntity.getBody()).getAccessions().get(0), notNullValue());
-    assertThat(Objects.requireNonNull(responseEntity.getBody()).getAccessions().size(), equalTo(1));
-    assertThat(Objects.requireNonNull(responseEntity.getBody()).getTotalRecords(), equalTo(1));
+    assertThat(Objects.requireNonNull(allAccessionQueueRecords.getBody()).getAccessions(), notNullValue());
+    assertThat(Objects.requireNonNull(allAccessionQueueRecords.getBody()).getAccessions().size(), equalTo(2));
+    assertThat(Objects.requireNonNull(allAccessionQueueRecords.getBody()).getTotalRecords(), equalTo(2));
+
+    ResponseEntity<AccessionQueues> accessionedRecords = get(formattedAccessionUrl + "?accessioned=true", AccessionQueues.class);
+
+    assertThat(Objects.requireNonNull(accessionedRecords.getBody()).getAccessions().get(0), notNullValue());
+    assertThat(Objects.requireNonNull(accessionedRecords.getBody()).getAccessions().size(), equalTo(1));
+    assertThat(Objects.requireNonNull(accessionedRecords.getBody()).getTotalRecords(), equalTo(1));
+    assertThat(Objects.requireNonNull(accessionedRecords.getBody()).getAccessions().get(0).getAccessionedDateTime(), notNullValue());
+
+    ResponseEntity<AccessionQueues> notAccessionedRecords = get(formattedAccessionUrl + "?accessioned=false", AccessionQueues.class);
+    assertThat(Objects.requireNonNull(notAccessionedRecords.getBody()).getAccessions().get(0), notNullValue());
+    assertThat(Objects.requireNonNull(notAccessionedRecords.getBody()).getAccessions().size(), equalTo(1));
+    assertThat(Objects.requireNonNull(notAccessionedRecords.getBody()).getTotalRecords(), equalTo(1));
+    assertThat(Objects.requireNonNull(notAccessionedRecords.getBody()).getAccessions().get(0).getAccessionedDateTime(), nullValue());
+
   }
 
   @Test

--- a/src/test/java/org/folio/rs/service/RetrievalQueueServiceTest.java
+++ b/src/test/java/org/folio/rs/service/RetrievalQueueServiceTest.java
@@ -4,6 +4,7 @@ import static org.folio.rs.util.MapperUtils.stringToUUIDSafe;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDateTime;
@@ -75,16 +76,25 @@ public class RetrievalQueueServiceTest extends TestBase {
     retrievalQueueRecord.setRetrievedDateTime(LocalDateTime.now());
     retrievalQueueRepository.save(retrievalQueueRecord);
 
-    ResponseEntity<RetrievalQueues> responseEntity = get(formattedRetrievalUrl + "?retrieved=true", RetrievalQueues.class);
+    ResponseEntity<RetrievalQueues> allRecords = get(formattedRetrievalUrl, RetrievalQueues.class);
 
-    assertThat(Objects.requireNonNull(responseEntity.getBody())
-      .getRetrievals()
-      .get(0), notNullValue());
-    assertThat(Objects.requireNonNull(responseEntity.getBody())
-      .getRetrievals()
-      .size(), equalTo(1));
-    assertThat(Objects.requireNonNull(responseEntity.getBody())
-      .getTotalRecords(), equalTo(1));
+    assertThat(Objects.requireNonNull(allRecords.getBody()).getRetrievals(), notNullValue());
+    assertThat(Objects.requireNonNull(allRecords.getBody()).getRetrievals().size(), equalTo(2));
+    assertThat(Objects.requireNonNull(allRecords.getBody()).getTotalRecords(), equalTo(2));
+
+    ResponseEntity<RetrievalQueues> retrievedRecord = get(formattedRetrievalUrl + "?retrieved=true", RetrievalQueues.class);
+
+    assertThat(Objects.requireNonNull(retrievedRecord.getBody()).getRetrievals().get(0), notNullValue());
+    assertThat(Objects.requireNonNull(retrievedRecord.getBody()).getRetrievals().size(), equalTo(1));
+    assertThat(Objects.requireNonNull(retrievedRecord.getBody()).getTotalRecords(), equalTo(1));
+    assertThat(Objects.requireNonNull(retrievedRecord.getBody()).getRetrievals().get(0).getRetrievedDateTime(), notNullValue());
+
+    ResponseEntity<RetrievalQueues> nonRetrievedRecord = get(formattedRetrievalUrl + "?retrieved=false", RetrievalQueues.class);
+
+    assertThat(Objects.requireNonNull(nonRetrievedRecord.getBody()).getRetrievals().get(0), notNullValue());
+    assertThat(Objects.requireNonNull(nonRetrievedRecord.getBody()).getRetrievals().size(), equalTo(1));
+    assertThat(Objects.requireNonNull(nonRetrievedRecord.getBody()).getTotalRecords(), equalTo(1));
+    assertThat(Objects.requireNonNull(nonRetrievedRecord.getBody()).getRetrievals().get(0).getRetrievedDateTime(), nullValue());
   }
 
   @Test


### PR DESCRIPTION
[MODRS-20](https://issues.folio.org/browse/MODRS-20) - Accessions API doesn't work with compound query

## Purpose
Fix compound query for accessioned records

## Approach
Enable query ?accessioned=false

### TODOS and Open Questions
 <!-- OPTIONAL
 - [ ] Use GitHub checklists. When solved, check the box and explain the answer.
 -->

## Learning
 <!-- OPTIONAL
   Help out not only your reviewer, but also your fellow developer!
   Sometimes there are key pieces of information that you used to come up
   with your solution. Don't let all that hard work go to waste! A
   pull request is a *perfect opportunity to share the learning that
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
