### PR TITLE
MODRS-57 - Check-In item by corresponding holdId

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -195,11 +195,20 @@
     },
     {
       "id": "remote-storage-check-in",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": ["POST"],
           "pathPattern": "/remote-storage/retrieve/{remoteStorageConfigurationId}/checkInItem",
+          "permissionsRequired" : ["remote-storage.check-in.item.post"],
+          "modulePermissions" : [
+            "inventory-storage.locations.item.get",
+            "circulation.check-in-by-barcode.post"
+          ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/remote-storage/retrieve/{remoteStorageConfigurationId}/checkInItemByHoldId",
           "permissionsRequired" : ["remote-storage.check-in.item.post"],
           "modulePermissions" : [
             "inventory-storage.locations.item.get",

--- a/src/main/java/org/folio/rs/controller/CheckInRetrieveController.java
+++ b/src/main/java/org/folio/rs/controller/CheckInRetrieveController.java
@@ -3,7 +3,6 @@ package org.folio.rs.controller;
 import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
 
-import io.swagger.annotations.ApiParam;
 import org.folio.rs.domain.dto.CheckInItem;
 import org.folio.rs.domain.dto.CheckInItemByHoldId;
 import org.folio.rs.rest.resource.RetrieveApi;
@@ -15,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -25,13 +25,17 @@ public class CheckInRetrieveController implements RetrieveApi {
   private final CheckInItemService checkInItemService;
 
   @Override
-  public ResponseEntity<String> checkInItemByBarcodeWithRemoteStorageConfigurationId(@Pattern(regexp="^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$") @ApiParam(value = "",required=true) @PathVariable("remoteStorageConfigurationId") String remoteStorageConfigurationId, @ApiParam(value = "" ,required=true )  @Valid @RequestBody CheckInItem checkInItem) {
+  public ResponseEntity<String> checkInItemByBarcodeWithRemoteStorageConfigurationId(
+      @Pattern(regexp = "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$") @ApiParam(required = true) @PathVariable("remoteStorageConfigurationId") String remoteStorageConfigurationId,
+      @ApiParam(required = true) @Valid @RequestBody CheckInItem checkInItem) {
     checkInItemService.checkInItemByBarcode(remoteStorageConfigurationId, checkInItem);
     return new ResponseEntity<>("Check-in was done for " + checkInItem.getItemBarcode(), HttpStatus.OK);
   }
 
   @Override
-  public ResponseEntity<String> checkInItemByHoldIdWithRemoteStorageConfigurationId(@ApiParam(value = "",required=true) @PathVariable("remoteStorageConfigurationId") String remoteStorageConfigurationId,@ApiParam(value = "" ,required=true )  @Valid @RequestBody CheckInItemByHoldId checkInItemByHoldId) {
+  public ResponseEntity<String> checkInItemByHoldIdWithRemoteStorageConfigurationId(
+      @ApiParam(value = "", required = true) @PathVariable("remoteStorageConfigurationId") String remoteStorageConfigurationId,
+      @ApiParam(required = true) @Valid @RequestBody CheckInItemByHoldId checkInItemByHoldId) {
     checkInItemService.checkInItemByHoldId(remoteStorageConfigurationId, checkInItemByHoldId);
     return new ResponseEntity<>("Check-in was done for item with holdId" + checkInItemByHoldId.getHoldId(), HttpStatus.OK);
   }

--- a/src/main/java/org/folio/rs/controller/CheckInRetrieveController.java
+++ b/src/main/java/org/folio/rs/controller/CheckInRetrieveController.java
@@ -1,7 +1,9 @@
 package org.folio.rs.controller;
 
-import lombok.RequiredArgsConstructor;
+import javax.validation.Valid;
+
 import org.folio.rs.domain.dto.CheckInItem;
+import org.folio.rs.domain.dto.CheckInItemByHoldId;
 import org.folio.rs.rest.resource.RetrieveApi;
 import org.folio.rs.service.CheckInItemService;
 import org.springframework.http.HttpStatus;
@@ -9,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,5 +24,11 @@ public class CheckInRetrieveController implements RetrieveApi {
   public ResponseEntity<String> checkInItemByBarcodeWithRemoteStorageConfigurationId(String remoteStorageConfigurationId, @Valid CheckInItem checkInItem) {
     checkInItemService.checkInItemByBarcode(remoteStorageConfigurationId, checkInItem);
     return new ResponseEntity<>("Check-in was done for " + checkInItem.getItemBarcode(), HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<String> checkInItemByHoldIdWithRemoteStorageConfigurationId(String remoteStorageConfigurationId, @Valid CheckInItemByHoldId checkInItemByHoldId) {
+    checkInItemService.checkInItemByHoldId(remoteStorageConfigurationId, checkInItemByHoldId);
+    return new ResponseEntity<>("Check-in was done for item with holdId" + checkInItemByHoldId.getHoldId(), HttpStatus.OK);
   }
 }

--- a/src/main/java/org/folio/rs/controller/CheckInRetrieveController.java
+++ b/src/main/java/org/folio/rs/controller/CheckInRetrieveController.java
@@ -1,13 +1,17 @@
 package org.folio.rs.controller;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
 
+import io.swagger.annotations.ApiParam;
 import org.folio.rs.domain.dto.CheckInItem;
 import org.folio.rs.domain.dto.CheckInItemByHoldId;
 import org.folio.rs.rest.resource.RetrieveApi;
 import org.folio.rs.service.CheckInItemService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,13 +25,13 @@ public class CheckInRetrieveController implements RetrieveApi {
   private final CheckInItemService checkInItemService;
 
   @Override
-  public ResponseEntity<String> checkInItemByBarcodeWithRemoteStorageConfigurationId(String remoteStorageConfigurationId, @Valid CheckInItem checkInItem) {
+  public ResponseEntity<String> checkInItemByBarcodeWithRemoteStorageConfigurationId(@Pattern(regexp="^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$") @ApiParam(value = "",required=true) @PathVariable("remoteStorageConfigurationId") String remoteStorageConfigurationId, @ApiParam(value = "" ,required=true )  @Valid @RequestBody CheckInItem checkInItem) {
     checkInItemService.checkInItemByBarcode(remoteStorageConfigurationId, checkInItem);
     return new ResponseEntity<>("Check-in was done for " + checkInItem.getItemBarcode(), HttpStatus.OK);
   }
 
   @Override
-  public ResponseEntity<String> checkInItemByHoldIdWithRemoteStorageConfigurationId(String remoteStorageConfigurationId, @Valid CheckInItemByHoldId checkInItemByHoldId) {
+  public ResponseEntity<String> checkInItemByHoldIdWithRemoteStorageConfigurationId(@ApiParam(value = "",required=true) @PathVariable("remoteStorageConfigurationId") String remoteStorageConfigurationId,@ApiParam(value = "" ,required=true )  @Valid @RequestBody CheckInItemByHoldId checkInItemByHoldId) {
     checkInItemService.checkInItemByHoldId(remoteStorageConfigurationId, checkInItemByHoldId);
     return new ResponseEntity<>("Check-in was done for item with holdId" + checkInItemByHoldId.getHoldId(), HttpStatus.OK);
   }

--- a/src/main/java/org/folio/rs/service/CheckInItemService.java
+++ b/src/main/java/org/folio/rs/service/CheckInItemService.java
@@ -1,29 +1,34 @@
 package org.folio.rs.service;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
-import org.apache.commons.lang3.StringUtils;
-import org.folio.rs.client.CirculationClient;
-import org.folio.rs.client.LocationClient;
-import org.folio.rs.domain.dto.CheckInCirculationRequest;
-import org.folio.rs.domain.dto.CheckInItem;
-import org.folio.rs.error.CheckInException;
-import org.folio.rs.repository.LocationMappingsRepository;
-import org.springframework.stereotype.Service;
+import static java.lang.String.format;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
+import org.folio.rs.client.CirculationClient;
+import org.folio.rs.client.LocationClient;
+import org.folio.rs.domain.dto.CheckInCirculationRequest;
+import org.folio.rs.domain.dto.CheckInItem;
+import org.folio.rs.domain.dto.CheckInItemByHoldId;
+import org.folio.rs.error.CheckInException;
+import org.folio.rs.repository.LocationMappingsRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
 
 @Service
-@RequiredArgsConstructor
 @Log4j2
+@RequiredArgsConstructor
 public class CheckInItemService {
 
   private final CirculationClient circulationClient;
   private final LocationMappingsRepository locationMappingsRepository;
   private final LocationClient locationClient;
+  private final RetrievalQueueService retrievalQueueService;
 
   public void checkInItemByBarcode(String remoteStorageConfigurationId, CheckInItem checkInItem) {
     log.info("Start check-in process for item with barcode " + checkInItem.getItemBarcode());
@@ -42,5 +47,18 @@ public class CheckInItemService {
         log.info("Check-in success for item with barcode " + checkInItem.getItemBarcode());
       }
     }
+  }
+
+  public void checkInItemByHoldId(String remoteStorageConfigurationId, CheckInItemByHoldId checkInItemByHoldId) {
+    var holdId = checkInItemByHoldId.getHoldId();
+    log.info("Start check-in process for item with associated request with id=" + holdId);
+    var retrievalQueueRecord = retrievalQueueService.getRetrievalByHoldId(holdId, remoteStorageConfigurationId);
+    var barcode = retrievalQueueRecord
+      .orElseThrow(() -> new CheckInException(
+        format("Retrieval Queue Record with holdId=%s not found for remoteStorageId=%s", holdId, remoteStorageConfigurationId)))
+      .getItemBarcode();
+    var checkInItemByBarcode = new CheckInItem();
+    checkInItemByBarcode.setItemBarcode(barcode);
+    checkInItemByBarcode(remoteStorageConfigurationId, checkInItemByBarcode);
   }
 }

--- a/src/main/java/org/folio/rs/service/CheckInItemService.java
+++ b/src/main/java/org/folio/rs/service/CheckInItemService.java
@@ -52,7 +52,7 @@ public class CheckInItemService {
   public void checkInItemByHoldId(String remoteStorageConfigurationId, CheckInItemByHoldId checkInItemByHoldId) {
     var holdId = checkInItemByHoldId.getHoldId();
     log.info("Start check-in process for item with associated request with id=" + holdId);
-    var retrievalQueueRecord = retrievalQueueService.getRetrievalByHoldId(holdId, remoteStorageConfigurationId);
+    var retrievalQueueRecord = retrievalQueueService.getLastRetrievalByHoldId(holdId, remoteStorageConfigurationId);
     var barcode = retrievalQueueRecord
       .orElseThrow(() -> new CheckInException(
         format("Retrieval Queue Record with holdId=%s not found for remoteStorageId=%s", holdId, remoteStorageConfigurationId)))

--- a/src/main/java/org/folio/rs/service/RetrievalQueueService.java
+++ b/src/main/java/org/folio/rs/service/RetrievalQueueService.java
@@ -155,11 +155,11 @@ public class RetrievalQueueService {
   }
 
   private Specification<RetrievalQueueRecord> hasHoldId(String id) {
-    return (record, criteria, builder) -> builder.equal(record.get(HOLD_ID), id);
+    return (rec, criteria, builder) -> builder.equal(rec.get(HOLD_ID), id);
   }
 
   private Specification<RetrievalQueueRecord> hasRemoteStorageId(String id) {
-    return (record, criteria, builder) -> builder.equal(record.get(REMOTE_STORAGE_ID), stringToUUIDSafe(id));
+    return (rec, criteria, builder) -> builder.equal(rec.get(REMOTE_STORAGE_ID), stringToUUIDSafe(id));
   }
 
   private LocationMapping getLocationMapping(Item item) {

--- a/src/main/java/org/folio/rs/service/RetrievalQueueService.java
+++ b/src/main/java/org/folio/rs/service/RetrievalQueueService.java
@@ -65,8 +65,15 @@ public class RetrievalQueueService {
     return retrievalQueueMapper.mapEntitiesToRetrievalQueueCollection(queueRecords);
   }
 
-  public Optional<RetrievalQueueRecord> getRetrievalByHoldId(String holdId, String remoteStorageId) {
-    return retrievalQueueRepository.findOne(Specification.where(hasHoldId(holdId).and(hasRemoteStorageId(remoteStorageId))));
+  /**
+   * This method returns last by creation time retrieval queue record searched by holdId and remoteStorageConfigurationId
+   * @param holdId - request(hold) id
+   * @param remoteStorageId - remote storage configuration id
+   * @return retrieval queue record
+   */
+  public Optional<RetrievalQueueRecord> getLastRetrievalByHoldId(String holdId, String remoteStorageId) {
+    return retrievalQueueRepository.findAll(Specification.where(hasHoldId(holdId)
+      .and(hasRemoteStorageId(remoteStorageId))), Sort.by(Sort.Direction.DESC, REQUEST_DATE_TIME)).stream().findFirst();
   }
 
   public void setRetrievedById(String retrievalQueueId) {

--- a/src/main/java/org/folio/rs/service/RetrievalQueueService.java
+++ b/src/main/java/org/folio/rs/service/RetrievalQueueService.java
@@ -10,19 +10,19 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
 import javax.persistence.EntityNotFoundException;
 import javax.persistence.criteria.Predicate;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+
 import org.folio.rs.client.InventoryClient;
 import org.folio.rs.client.ServicePointsClient;
 import org.folio.rs.client.UsersClient;
+import org.folio.rs.domain.dto.EventRequest;
 import org.folio.rs.domain.dto.FilterData;
 import org.folio.rs.domain.dto.Item;
 import org.folio.rs.domain.dto.ItemContributorNames;
 import org.folio.rs.domain.dto.ItemEffectiveCallNumberComponents;
 import org.folio.rs.domain.dto.LocationMapping;
-import org.folio.rs.domain.dto.EventRequest;
 import org.folio.rs.domain.dto.PickupServicePoint;
 import org.folio.rs.domain.dto.ResultList;
 import org.folio.rs.domain.dto.RetrievalQueues;
@@ -35,6 +35,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
 @Service
 @Log4j2
 @RequiredArgsConstructor
@@ -45,6 +48,7 @@ public class RetrievalQueueService {
   private static final String RETRIEVED_DATE_TIME = "retrievedDateTime";
   private static final String REMOTE_STORAGE_ID = "remoteStorageId";
   private static final String REQUEST_DATE_TIME = "createdDateTime";
+  private static final String HOLD_ID = "holdId";
   private static final String NOT_FOUND = " not found";
   private static final String REQUEST_TYPE_DEFAULT = "PYR";
   private final RetrievalQueueRepository retrievalQueueRepository;
@@ -59,6 +63,10 @@ public class RetrievalQueueService {
     var queueRecords = retrievalQueueRepository.findAll(getCriteriaSpecification(filterData),
         new OffsetRequest(filterData.getOffset(), filterData.getLimit(), Sort.unsorted()));
     return retrievalQueueMapper.mapEntitiesToRetrievalQueueCollection(queueRecords);
+  }
+
+  public Optional<RetrievalQueueRecord> getRetrievalByHoldId(String holdId, String remoteStorageId) {
+    return retrievalQueueRepository.findOne(Specification.where(hasHoldId(holdId).and(hasRemoteStorageId(remoteStorageId))));
   }
 
   public void setRetrievedById(String retrievalQueueId) {
@@ -114,6 +122,9 @@ public class RetrievalQueueService {
       if (Objects.nonNull(filterData.getCreateDate())) {
         predicates.add(builder.equal(record.get(REQUEST_DATE_TIME), LocalDateTime.parse(filterData.getCreateDate())));
       }
+      if (Objects.nonNull(filterData.getCreateDate())) {
+        predicates.add(builder.equal(record.get(REQUEST_DATE_TIME), LocalDateTime.parse(filterData.getCreateDate())));
+      }
       return builder.and(predicates.toArray(new Predicate[0]));
     };
   }
@@ -134,6 +145,14 @@ public class RetrievalQueueService {
 
   private Specification<RetrievalQueueRecord> hasId(String id) {
     return (record, criteria, builder) -> builder.equal(record.get(ID), stringToUUIDSafe(id));
+  }
+
+  private Specification<RetrievalQueueRecord> hasHoldId(String id) {
+    return (record, criteria, builder) -> builder.equal(record.get(HOLD_ID), id);
+  }
+
+  private Specification<RetrievalQueueRecord> hasRemoteStorageId(String id) {
+    return (record, criteria, builder) -> builder.equal(record.get(REMOTE_STORAGE_ID), stringToUUIDSafe(id));
   }
 
   private LocationMapping getLocationMapping(Item item) {

--- a/src/main/resources/swagger.api/remote-storage.yaml
+++ b/src/main/resources/swagger.api/remote-storage.yaml
@@ -455,6 +455,15 @@ paths:
             text/plain:
               schema:
                 type: string
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Bad request
+        '422':
+          $ref: "#/components/responses/trait_validate_422"
         '500':
           description: Internal server error
           content:
@@ -469,7 +478,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: "#/components/schemas/uuid"
       requestBody:
         content:
           application/json:
@@ -485,6 +494,15 @@ paths:
             text/plain:
               schema:
                 type: string
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Bad request
+        '422':
+          $ref: "#/components/responses/trait_validate_422"
         '500':
           description: Internal server error
           content:

--- a/src/main/resources/swagger.api/remote-storage.yaml
+++ b/src/main/resources/swagger.api/remote-storage.yaml
@@ -476,6 +476,36 @@ paths:
             schema:
               $ref: "#/components/schemas/checkInItem"
         required: true
+  /retrieve/{remoteStorageConfigurationId}/checkInItemByHoldId:
+    post:
+      responses:
+        '200':
+          description: Checked-in the item by holdId
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Internal server error
+      description: Check-in the item in the primary service by barcode value
+      operationId: checkInItemByHoldIdWithRemoteStorageConfigurationId
+      parameters:
+        - name: remoteStorageConfigurationId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/checkInItemByHoldId"
+        required: true
   /return/{remoteStorageConfigurationId}:
     post:
       responses:
@@ -574,6 +604,8 @@ components:
       $ref: schemas/uuid.json
     checkInItem:
       $ref: schemas/checkInItem.json
+    checkInItemByHoldId:
+      $ref: schemas/checkInItemByHoldId.json
     returnItemResponse:
       $ref: schemas/returnItemResponse.json
     pubSubEvent:

--- a/src/main/resources/swagger.api/schemas/checkInItemByHoldId.json
+++ b/src/main/resources/swagger.api/schemas/checkInItemByHoldId.json
@@ -5,7 +5,7 @@
   "properties": {
     "holdId": {
       "description": "Id of request (hold) for which item should be checked in",
-      "type": "string"
+      "$ref": "uuid.json"
     }
   },
   "additionalProperties": false,

--- a/src/main/resources/swagger.api/schemas/checkInItemByHoldId.json
+++ b/src/main/resources/swagger.api/schemas/checkInItemByHoldId.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Value of request's id for which item should be checked in at service points",
+  "properties": {
+    "holdId": {
+      "description": "Id of request (hold) for which item should be checked in",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "holdId"
+  ]
+}

--- a/src/test/java/org/folio/rs/controller/CheckInRetrieveTest.java
+++ b/src/test/java/org/folio/rs/controller/CheckInRetrieveTest.java
@@ -1,8 +1,20 @@
 package org.folio.rs.controller;
 
+import static org.folio.rs.util.MapperUtils.stringToUUIDSafe;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+
 import org.folio.rs.TestBase;
+import org.folio.rs.domain.dto.CheckInItem;
+import org.folio.rs.domain.dto.CheckInItemByHoldId;
 import org.folio.rs.domain.entity.LocationMapping;
+import org.folio.rs.domain.entity.RetrievalQueueRecord;
 import org.folio.rs.repository.LocationMappingsRepository;
+import org.folio.rs.repository.RetrievalQueueRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,25 +22,27 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 
-import java.util.UUID;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 public class CheckInRetrieveTest extends TestBase {
 
   private static final String CHECK_IN_URL = "http://localhost:%s/remote-storage/retrieve/%s/checkInItem";
+  private static final String CHECK_IN_BY_HOLD_ID_URL = "http://localhost:%s/remote-storage/retrieve/%s/checkInItemByHoldId";
   private static final String REMOTE_STORAGE_CONFIGURATION_ID = "de17bad7-2a30-4f1c-bee5-f653ded15629";
   private static final String FOLIO_LOCATION_ID = "53cf956f-c1df-410b-8bea-27f712cca7c0";
+  private static final String HOLD_ID = "5c3c7621-8ad0-43ca-a675-4f2f32d25b27";
+  private static final String HOLD_ID_NOT_FOUND = "d83bc442-6705-41dd-b199-07c3c2083db6";
+  private static final String ITEM_BARCODE = "2887532577331";
   private static final String REMOTE_STORAGE_ERROR_CONFIGURATION_ID = "de17bad7-2a30-4f1c-bee5-f653ded15628";
 
   private String checkInUrl;
+  private String checkInByHoldIdUrl;
   private String errorCheckInUrl;
+  private String errorCheckInByHoldIdUrl;
 
   @Autowired
   private LocationMappingsRepository locationMappingsRepository;
+
+  @Autowired
+  private RetrievalQueueRepository retrievalQueueRepository;
 
   @BeforeEach
   void prepare() {
@@ -36,8 +50,16 @@ public class CheckInRetrieveTest extends TestBase {
     locationMapping.setFolioLocationId(UUID.fromString(FOLIO_LOCATION_ID));
     locationMapping.setConfigurationId(UUID.fromString(REMOTE_STORAGE_CONFIGURATION_ID));
     locationMappingsRepository.save(locationMapping);
+    retrievalQueueRepository.save(RetrievalQueueRecord.builder()
+      .id(UUID.randomUUID())
+      .holdId(HOLD_ID)
+      .remoteStorageId(stringToUUIDSafe(REMOTE_STORAGE_CONFIGURATION_ID))
+      .itemBarcode(ITEM_BARCODE)
+      .build());
     checkInUrl = String.format(CHECK_IN_URL, okapiPort, REMOTE_STORAGE_CONFIGURATION_ID);
+    checkInByHoldIdUrl = String.format(CHECK_IN_BY_HOLD_ID_URL, okapiPort, REMOTE_STORAGE_CONFIGURATION_ID);
     errorCheckInUrl = String.format(CHECK_IN_URL, okapiPort, REMOTE_STORAGE_ERROR_CONFIGURATION_ID);
+    errorCheckInByHoldIdUrl = String.format(CHECK_IN_BY_HOLD_ID_URL, okapiPort, REMOTE_STORAGE_ERROR_CONFIGURATION_ID);
   }
 
   @AfterEach
@@ -47,15 +69,41 @@ public class CheckInRetrieveTest extends TestBase {
 
   @Test
   void canCheckInItemByBarcodeWithRemoteStorageConfigurationIdPost() {
-    var itemBarcode = "{\"itemBarcode\": \"2887532577331\"}";
-    var response = post(checkInUrl, itemBarcode, String.class);
+    var checkInItem = new CheckInItem();
+    checkInItem.setItemBarcode(ITEM_BARCODE);
+    var response = post(checkInUrl, checkInItem, String.class);
     assertThat(response.getStatusCode(), is(HttpStatus.OK));
   }
 
   @Test
   void shouldReturnBadRequestForInvalidRemoteStorageId() {
-    var itemBarcode = "{\"itemBarcode\": \"2887532577331\"}";
-    var exception = assertThrows(HttpClientErrorException.class, () -> post(errorCheckInUrl, itemBarcode, String.class));
+    var checkInItem = new CheckInItem();
+    checkInItem.setItemBarcode(ITEM_BARCODE);
+    var exception = assertThrows(HttpClientErrorException.class, () -> post(errorCheckInUrl, checkInItem, String.class));
+    assertThat(exception.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void canCheckInItemByHoldIdWithRemoteStorageConfigurationIdPost() {
+    var checkInByHoldId = new CheckInItemByHoldId();
+    checkInByHoldId.setHoldId(HOLD_ID);
+    var response = post(checkInByHoldIdUrl, checkInByHoldId, String.class);
+    assertThat(response.getStatusCode(), is(HttpStatus.OK));
+  }
+
+  @Test
+  void testCheckInByHoldIdForInvalidRemoteStorageId() {
+    var checkInByHoldId = new CheckInItemByHoldId();
+    checkInByHoldId.setHoldId(HOLD_ID);
+    var exception = assertThrows(HttpClientErrorException.class, () -> post(errorCheckInByHoldIdUrl, checkInByHoldId, String.class));
+    assertThat(exception.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void testCheckInByHoldIdForInvalidHoldId() {
+    var checkInByHoldId = new CheckInItemByHoldId();
+    checkInByHoldId.setHoldId(HOLD_ID_NOT_FOUND);
+    var exception = assertThrows(HttpClientErrorException.class, () -> post(checkInByHoldIdUrl, checkInByHoldId, String.class));
     assertThat(exception.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
   }
 }

--- a/src/test/java/org/folio/rs/controller/CheckInRetrieveTest.java
+++ b/src/test/java/org/folio/rs/controller/CheckInRetrieveTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.folio.rs.TestBase;
@@ -55,6 +56,7 @@ public class CheckInRetrieveTest extends TestBase {
       .holdId(HOLD_ID)
       .remoteStorageId(stringToUUIDSafe(REMOTE_STORAGE_CONFIGURATION_ID))
       .itemBarcode(ITEM_BARCODE)
+      .createdDateTime(LocalDateTime.now())
       .build());
     checkInUrl = String.format(CHECK_IN_URL, okapiPort, REMOTE_STORAGE_CONFIGURATION_ID);
     checkInByHoldIdUrl = String.format(CHECK_IN_BY_HOLD_ID_URL, okapiPort, REMOTE_STORAGE_CONFIGURATION_ID);
@@ -85,25 +87,35 @@ public class CheckInRetrieveTest extends TestBase {
 
   @Test
   void canCheckInItemByHoldIdWithRemoteStorageConfigurationIdPost() {
-    var checkInByHoldId = new CheckInItemByHoldId();
-    checkInByHoldId.setHoldId(HOLD_ID);
+    var checkInByHoldId = getCheckInItemByHoldIdSample(HOLD_ID);
     var response = post(checkInByHoldIdUrl, checkInByHoldId, String.class);
     assertThat(response.getStatusCode(), is(HttpStatus.OK));
   }
 
   @Test
-  void testCheckInByHoldIdForInvalidRemoteStorageId() {
-    var checkInByHoldId = new CheckInItemByHoldId();
-    checkInByHoldId.setHoldId(HOLD_ID);
+  void testCheckInByHoldIdForErrorRemoteStorageId() {
+    var checkInByHoldId = getCheckInItemByHoldIdSample(HOLD_ID);
     var exception = assertThrows(HttpClientErrorException.class, () -> post(errorCheckInByHoldIdUrl, checkInByHoldId, String.class));
     assertThat(exception.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
   }
 
   @Test
-  void testCheckInByHoldIdForInvalidHoldId() {
-    var checkInByHoldId = new CheckInItemByHoldId();
-    checkInByHoldId.setHoldId(HOLD_ID_NOT_FOUND);
+  void testCheckInByHoldIdForErrorHoldId() {
+    var checkInByHoldId = getCheckInItemByHoldIdSample(HOLD_ID_NOT_FOUND);
     var exception = assertThrows(HttpClientErrorException.class, () -> post(checkInByHoldIdUrl, checkInByHoldId, String.class));
     assertThat(exception.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void testCheckInByHoldIdForInvalidHoldId() {
+    CheckInItemByHoldId checkInByHoldId = getCheckInItemByHoldIdSample("invalid-id");
+    var exception = assertThrows(HttpClientErrorException.class, () -> post(checkInByHoldIdUrl, checkInByHoldId, String.class));
+    assertThat(exception.getStatusCode(), equalTo(HttpStatus.UNPROCESSABLE_ENTITY));
+  }
+
+  private CheckInItemByHoldId getCheckInItemByHoldIdSample(String holdId) {
+    var checkInByHoldId = new CheckInItemByHoldId();
+    checkInByHoldId.setHoldId(holdId);
+    return checkInByHoldId;
   }
 }

--- a/src/test/java/org/folio/rs/service/CheckInItemServiceTest.java
+++ b/src/test/java/org/folio/rs/service/CheckInItemServiceTest.java
@@ -1,12 +1,21 @@
 package org.folio.rs.service;
 
-import joptsimple.internal.Strings;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+
 import org.folio.rs.client.CirculationClient;
 import org.folio.rs.client.LocationClient;
 import org.folio.rs.domain.dto.CheckInCirculationRequest;
 import org.folio.rs.domain.dto.CheckInItem;
+import org.folio.rs.domain.dto.CheckInItemByHoldId;
 import org.folio.rs.domain.dto.FolioLocation;
 import org.folio.rs.domain.entity.LocationMapping;
+import org.folio.rs.domain.entity.RetrievalQueueRecord;
 import org.folio.rs.error.CheckInException;
 import org.folio.rs.repository.LocationMappingsRepository;
 import org.junit.jupiter.api.Assertions;
@@ -17,13 +26,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import joptsimple.internal.Strings;
 
 @ExtendWith(MockitoExtension.class)
 public class CheckInItemServiceTest {
@@ -31,12 +34,16 @@ public class CheckInItemServiceTest {
   private static final String REMOTE_STORAGE_CONFIGURATION_ID = "de17bad7-2a30-4f1c-bee5-f653ded15629";
   private static final String FOLIO_LOCATION_ID = "53cf956f-c1df-410b-8bea-27f712cca7c0";
   private static final String PRIMARY_SERVICE_POINT = "79faacf1-4ba4-42c7-8b2a-566b259e4641";
+  private static final String HOLD_ID = "bdf5534b-685e-4f71-9fe6-cc2313504508";
+  private static final String ITEM_BARCODE = "item-barcode";
   @Mock
   private CirculationClient circulationClient;
   @Mock
   private LocationMappingsRepository locationMappingsRepository;
   @Mock
   private LocationClient locationClient;
+  @Mock
+  private RetrievalQueueService retrievalQueueService;
 
   @InjectMocks
   private CheckInItemService checkInItemService;
@@ -44,6 +51,8 @@ public class CheckInItemServiceTest {
   private LocationMapping locationMapping;
   private FolioLocation folioLocation;
   private CheckInItem checkInItem;
+  private CheckInItemByHoldId checkInItemByHoldId;
+  private RetrievalQueueRecord retrievalQueueRecord;
 
   @BeforeEach
   public void prepare() {
@@ -51,8 +60,11 @@ public class CheckInItemServiceTest {
     locationMapping.setFolioLocationId(UUID.fromString(FOLIO_LOCATION_ID));
     locationMapping.setConfigurationId(UUID.fromString(REMOTE_STORAGE_CONFIGURATION_ID));
     folioLocation = FolioLocation.of(FOLIO_LOCATION_ID, Strings.EMPTY, PRIMARY_SERVICE_POINT);
+    retrievalQueueRecord = RetrievalQueueRecord.builder().id(UUID.randomUUID()).holdId(HOLD_ID).itemBarcode(ITEM_BARCODE).build();
     checkInItem = new CheckInItem();
-    checkInItem.setItemBarcode("item-barcode");
+    checkInItem.setItemBarcode(ITEM_BARCODE);
+    checkInItemByHoldId = new CheckInItemByHoldId();
+    checkInItemByHoldId.setHoldId(HOLD_ID);
   }
 
   @Test
@@ -63,6 +75,20 @@ public class CheckInItemServiceTest {
       .thenReturn(folioLocation);
 
     checkInItemService.checkInItemByBarcode(REMOTE_STORAGE_CONFIGURATION_ID, checkInItem);
+
+    verify(circulationClient, times(1)).checkIn(isA(CheckInCirculationRequest.class));
+  }
+
+  @Test
+  void testCheckInItemByHoldId() {
+    when(locationMappingsRepository.getFirstByConfigurationId(UUID.fromString(REMOTE_STORAGE_CONFIGURATION_ID)))
+      .thenReturn(Optional.of(locationMapping));
+    when(locationClient.getLocation(FOLIO_LOCATION_ID))
+      .thenReturn(folioLocation);
+    when(retrievalQueueService.getRetrievalByHoldId(HOLD_ID, REMOTE_STORAGE_CONFIGURATION_ID))
+      .thenReturn(Optional.of(retrievalQueueRecord));
+
+    checkInItemService.checkInItemByHoldId(REMOTE_STORAGE_CONFIGURATION_ID, checkInItemByHoldId);
 
     verify(circulationClient, times(1)).checkIn(isA(CheckInCirculationRequest.class));
   }

--- a/src/test/java/org/folio/rs/service/CheckInItemServiceTest.java
+++ b/src/test/java/org/folio/rs/service/CheckInItemServiceTest.java
@@ -85,7 +85,7 @@ public class CheckInItemServiceTest {
       .thenReturn(Optional.of(locationMapping));
     when(locationClient.getLocation(FOLIO_LOCATION_ID))
       .thenReturn(folioLocation);
-    when(retrievalQueueService.getRetrievalByHoldId(HOLD_ID, REMOTE_STORAGE_CONFIGURATION_ID))
+    when(retrievalQueueService.getLastRetrievalByHoldId(HOLD_ID, REMOTE_STORAGE_CONFIGURATION_ID))
       .thenReturn(Optional.of(retrievalQueueRecord));
 
     checkInItemService.checkInItemByHoldId(REMOTE_STORAGE_CONFIGURATION_ID, checkInItemByHoldId);


### PR DESCRIPTION
[MODRS-57](https://issues.folio.org/browse/MODRS-57) - Check-In item by corresponding holdId

## Purpose
API for check in item by corresponding request id.

## Approach
Item is retrieved from Retrieval Queue by holdId and remoteStorageConfigurationId and checked in.

### TODOS and Open Questions
 <!-- OPTIONAL
 - [ ] Use GitHub checklists. When solved, check the box and explain the answer.
 -->

## Learning
 <!-- OPTIONAL
   Help out not only your reviewer, but also your fellow developer!
   Sometimes there are key pieces of information that you used to come up
   with your solution. Don't let all that hard work go to waste! A
   pull request is a *perfect opportunity to share the learning that
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
