### PR TITLE
MODRS-68 - Accession queue records created as already accessioned

### DIFF
--- a/src/main/java/org/folio/rs/service/AccessionQueueService.java
+++ b/src/main/java/org/folio/rs/service/AccessionQueueService.java
@@ -129,6 +129,7 @@ public class AccessionQueueService {
 
     changeItemPermanentLocation(item, remoteLocationId);
     var accessionQueueRecord = buildAccessionQueueRecord(item, instance, locationMapping);
+    accessionQueueRecord.setAccessionedDateTime(LocalDateTime.now());
     accessionQueueRepository.save(accessionQueueRecord);
     return accessionQueueMapper.mapEntityToDto(accessionQueueRecord);
   }
@@ -278,7 +279,6 @@ public class AccessionQueueService {
       .id(UUID.randomUUID())
       .itemBarcode(item.getBarcode())
       .createdDateTime(LocalDateTime.now())
-      .accessionedDateTime(LocalDateTime.now())
       .remoteStorageId(UUID.fromString(locationMapping.getConfigurationId()))
       .callNumber(ofNullable(item.getEffectiveCallNumberComponents())
         .map(ItemEffectiveCallNumberComponents::getCallNumber)

--- a/src/test/java/org/folio/rs/service/AccessionQueueServiceTest.java
+++ b/src/test/java/org/folio/rs/service/AccessionQueueServiceTest.java
@@ -597,6 +597,7 @@ public class AccessionQueueServiceTest extends TestBase {
     assertThat(accessionQueueRecord.getRemoteStorageId(), equalTo(UUID.fromString(REMOTE_STORAGE_ID)));
     assertThat(accessionQueueRecord.getInstanceAuthor(), equalTo(INSTANCE_AUTHOR));
     assertThat(accessionQueueRecord.getInstanceTitle(), equalTo(INSTANCE_TITLE));
+    assertThat(accessionQueueRecord.getAccessionedDateTime(), nullValue());
   }
 
 }


### PR DESCRIPTION
[MODRS-68](https://issues.folio.org/browse/MODRS-68) - Accession queue records created as already accessioned

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
