### PR TITLE
MODRS-68 - Accession queue records created as already accessioned

### DIFF
--- a/src/main/java/org/folio/rs/controller/AccessionController.java
+++ b/src/main/java/org/folio/rs/controller/AccessionController.java
@@ -29,9 +29,9 @@ public class AccessionController implements AccessionsApi {
   private final AccessionQueueService accessionQueueService;
 
   @Override
-  public ResponseEntity<AccessionQueues> getAccessions(@Valid Boolean accessioned, @Valid String remoteStorageConfigurationId,
+  public ResponseEntity<AccessionQueues> getAccessions(@Valid Boolean accessioned, @Valid String storageId,
       @Valid String createdDate, @Min(0) @Max(2147483647) @Valid Integer offset, @Min(0) @Max(2147483647) @Valid Integer limit) {
-    var accessionQueues = accessionQueueService.getAccessions(getFilterData(accessioned, remoteStorageConfigurationId, createdDate, offset, limit));
+    var accessionQueues = accessionQueueService.getAccessions(getFilterData(accessioned, storageId, createdDate, offset, limit));
     return new ResponseEntity<>(accessionQueues, HttpStatus.OK);
   }
 

--- a/src/main/java/org/folio/rs/service/AccessionQueueService.java
+++ b/src/main/java/org/folio/rs/service/AccessionQueueService.java
@@ -129,6 +129,7 @@ public class AccessionQueueService {
 
     changeItemPermanentLocation(item, remoteLocationId);
     var accessionQueueRecord = buildAccessionQueueRecord(item, instance, locationMapping);
+    accessionQueueRecord.setAccessionedDateTime(LocalDateTime.now());
     accessionQueueRepository.save(accessionQueueRecord);
     return accessionQueueMapper.mapEntityToDto(accessionQueueRecord);
   }
@@ -278,7 +279,6 @@ public class AccessionQueueService {
       .id(UUID.randomUUID())
       .itemBarcode(item.getBarcode())
       .createdDateTime(LocalDateTime.now())
-      .accessionedDateTime(LocalDateTime.now())
       .remoteStorageId(UUID.fromString(locationMapping.getConfigurationId()))
       .callNumber(ofNullable(item.getEffectiveCallNumberComponents())
         .map(ItemEffectiveCallNumberComponents::getCallNumber)

--- a/src/main/resources/swagger.api/remote-storage.yaml
+++ b/src/main/resources/swagger.api/remote-storage.yaml
@@ -475,7 +475,7 @@ paths:
       operationId: getAccessions
       parameters:
         - $ref: "#/components/parameters/trait_queryable_accessioned"
-        - $ref: "#/components/parameters/trait_queryable_configuration_id"
+        - $ref: "#/components/parameters/trait_queryable_storage_id"
         - $ref: "#/components/parameters/trait_queryable_created_date"
         - $ref: "#/components/parameters/trait_pageable_offset"
         - $ref: "#/components/parameters/trait_pageable_limit"
@@ -552,7 +552,7 @@ paths:
       operationId: getRetrievals
       parameters:
         - $ref: "#/components/parameters/trait_queryable_retrieved"
-        - $ref: "#/components/parameters/trait_queryable_configuration_id"
+        - $ref: "#/components/parameters/trait_queryable_storage_id"
         - $ref: "#/components/parameters/trait_queryable_created_date"
         - $ref: "#/components/parameters/trait_pageable_offset"
         - $ref: "#/components/parameters/trait_pageable_limit"
@@ -818,6 +818,12 @@ components:
       name: remoteStorageConfigurationId
       in: query
       description: Remote storage configuration id
+      schema:
+        type: string
+    trait_queryable_storage_id:
+      name: storageId
+      in: query
+      description: Remote storage id
       schema:
         type: string
     trait_queryable_accessioned:

--- a/src/test/java/org/folio/rs/service/AccessionQueueServiceTest.java
+++ b/src/test/java/org/folio/rs/service/AccessionQueueServiceTest.java
@@ -597,6 +597,7 @@ public class AccessionQueueServiceTest extends TestBase {
     assertThat(accessionQueueRecord.getRemoteStorageId(), equalTo(UUID.fromString(REMOTE_STORAGE_ID)));
     assertThat(accessionQueueRecord.getInstanceAuthor(), equalTo(INSTANCE_AUTHOR));
     assertThat(accessionQueueRecord.getInstanceTitle(), equalTo(INSTANCE_TITLE));
+    assertThat(accessionQueueRecord.getAccessionedDateTime(), nullValue());
   }
 
 }

--- a/src/test/java/org/folio/rs/service/AccessionQueueServiceTest.java
+++ b/src/test/java/org/folio/rs/service/AccessionQueueServiceTest.java
@@ -135,7 +135,7 @@ public class AccessionQueueServiceTest extends TestBase {
     accessionQueueRepository.save(createBaseAccessionQueueRecord());
     accessionQueueRepository.save(buildAccessionQueueRecord(stringToUUIDSafe(ACCESSION_RECORD_1_ID)));
 
-    ResponseEntity<AccessionQueues> responseEntity = get(formattedAccessionUrl +"?remoteStorageConfigurationId=" + REMOTE_STORAGE_ID, AccessionQueues.class);
+    ResponseEntity<AccessionQueues> responseEntity = get(formattedAccessionUrl +"?storageId=" + REMOTE_STORAGE_ID, AccessionQueues.class);
     assertThat(Objects.requireNonNull(responseEntity.getBody()).getAccessions().get(0).getRemoteStorageId(), equalTo(REMOTE_STORAGE_ID));
     assertThat(Objects.requireNonNull(responseEntity.getBody()).getAccessions().size(), equalTo(1));
     assertThat(Objects.requireNonNull(responseEntity.getBody()).getTotalRecords(), equalTo(1));

--- a/src/test/java/org/folio/rs/service/ReturnRetrievalQueueServiceTest.java
+++ b/src/test/java/org/folio/rs/service/ReturnRetrievalQueueServiceTest.java
@@ -59,7 +59,7 @@ public class ReturnRetrievalQueueServiceTest extends TestBase {
     returnRetrievalQueueRepository.save(createBaseRetrievalQueueRecord());
     returnRetrievalQueueRepository.save(buildRetrievalQueueRecord(stringToUUIDSafe(RETRIEVAL_RECORD_1_ID)));
 
-    ResponseEntity<RetrievalQueues> responseEntity = get(formattedRetrievalUrl + "?remoteStorageConfigurationId=" + REMOTE_STORAGE_ID,
+    ResponseEntity<RetrievalQueues> responseEntity = get(formattedRetrievalUrl + "?storageId=" + REMOTE_STORAGE_ID,
         RetrievalQueues.class);
     assertThat(Objects.requireNonNull(responseEntity.getBody())
       .getRetrievals()


### PR DESCRIPTION
[MODRS-68](https://issues.folio.org/browse/MODRS-68) - Accession queue records created as already accessioned


## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
