### PR TITLE
MODRS-48 - Configuration fields enhancement

### DIFF
--- a/src/main/resources/swagger.api/schemas/storageConfiguration.json
+++ b/src/main/resources/swagger.api/schemas/storageConfiguration.json
@@ -29,7 +29,8 @@
     },
     "accessionDelay": {
       "description": "accession schedule delay",
-      "type": "integer"
+      "type": "integer",
+      "minimum": 1
     },
     "accessionTimeUnit": {
       "description": "accession schedule time unit",

--- a/src/test/java/org/folio/rs/controller/ConfigurationsTest.java
+++ b/src/test/java/org/folio/rs/controller/ConfigurationsTest.java
@@ -2,7 +2,6 @@ package org.folio.rs.controller;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
-import static org.folio.rs.domain.dto.ReturningWorkflowDetails.CAIASOFT;
 import static org.folio.rs.util.Utils.randomIdAsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -218,6 +217,46 @@ public class ConfigurationsTest extends TestBase {
     HttpClientErrorException exception = assertThrows(HttpClientErrorException.class,
         () -> put(urlWithAnotherUuid, configurationDto));
     assertThat(exception.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void shouldReturnUnprocessableEntityIfAccessionDelayHasWrongValue() {
+    var configuration = new StorageConfiguration()
+      .name("name")
+      .providerName("provider")
+      .accessionDelay(0)
+      .accessionTimeUnit(TimeUnits.MINUTES);
+
+    var exception = assertThrows(HttpClientErrorException.class,
+      () -> post(configurationsUrl, configuration, StorageConfiguration.class));
+    assertThat(exception.getStatusCode(), equalTo(HttpStatus.UNPROCESSABLE_ENTITY));
+
+    configuration.accessionDelay(-1);
+
+    exception = assertThrows(HttpClientErrorException.class,
+      () -> post(configurationsUrl, configuration, StorageConfiguration.class));
+    assertThat(exception.getStatusCode(), equalTo(HttpStatus.UNPROCESSABLE_ENTITY));
+  }
+
+  @Test
+  void shouldReturnUnprocessableEntityIfRequiredFieldsAreMissing() {
+    var configurationMissingName = new StorageConfiguration()
+      .providerName("provider")
+      .accessionDelay(1)
+      .accessionTimeUnit(TimeUnits.MINUTES);
+
+    var exception = assertThrows(HttpClientErrorException.class,
+      () -> post(configurationsUrl, configurationMissingName, StorageConfiguration.class));
+    assertThat(exception.getStatusCode(), equalTo(HttpStatus.UNPROCESSABLE_ENTITY));
+
+     var configurationMissingProviderName = new StorageConfiguration()
+      .name("name")
+      .accessionDelay(1)
+      .accessionTimeUnit(TimeUnits.MINUTES);
+
+    exception = assertThrows(HttpClientErrorException.class,
+      () -> post(configurationsUrl, configurationMissingProviderName, StorageConfiguration.class));
+    assertThat(exception.getStatusCode(), equalTo(HttpStatus.UNPROCESSABLE_ENTITY));
   }
 
   private StorageConfiguration buildConfiguration(String id) {


### PR DESCRIPTION
[MODRS-48](https://issues.folio.org/browse/MODRS-48) - Configuration fields enhancement

## Purpose
In order to protect logical meaning of the remote storage configuration fields one need to enhance current Configurations API implementation/data structure.
Requirements/Scope:
* `accessionDelay` should be natural number
* `name`, `providerName` should be required

## Approach
* Updated configurations API so that in case of invalid values corresponding 422 error with description is returned to client
* Updated unit tests

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
