### PR TITLE
MODRS-82 - Make system user updatable

### DIFF
--- a/src/main/java/org/folio/rs/controller/TenantController.java
+++ b/src/main/java/org/folio/rs/controller/TenantController.java
@@ -114,7 +114,7 @@ public class TenantController implements TenantApi {
 
   private void initializeSystemUser(String tenantId) {
     try {
-      securityManagerService.prepareSystemUser(SYSTEM_USER, SYSTEM_USER, context.getOkapiUrl(), tenantId);
+      securityManagerService.prepareOrUpdateSystemUser(SYSTEM_USER, SYSTEM_USER, context.getOkapiUrl(), tenantId);
     } catch (Exception e) {
       log.error("Error initializing System User", e);
     }

--- a/src/test/java/org/folio/rs/service/SecurityManagerServiceTest.java
+++ b/src/test/java/org/folio/rs/service/SecurityManagerServiceTest.java
@@ -1,15 +1,17 @@
 package org.folio.rs.service;
 
 import static java.util.stream.Collectors.toList;
+import static org.folio.rs.controller.TenantController.SYSTEM_USER;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.UUID;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.folio.rs.TestBase;
 import org.folio.rs.domain.entity.SystemUserParameters;
-import org.folio.rs.repository.SystemUserParametersRepository;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -20,45 +22,42 @@ public class SecurityManagerServiceTest extends TestBase {
   @Autowired
   SecurityManagerService securityManagerService;
 
-  @Autowired
-  private SystemUserParametersRepository credentialsRepository;
-
   public static final String EXISTED_USER = "existed_user";
   public static final String NON_EXISTED_USER = "non_existed_user";
   public static final String NON_PRESENTED_USER = "non_presented_user";
 
   @Test
   void testCreateDefaultSystemUser() {
-    securityManagerService.prepareSystemUser(NON_PRESENTED_USER, PASSWORD, getOkapiUrl(), TEST_TENANT);
+    securityManagerService.prepareOrUpdateSystemUser(NON_PRESENTED_USER, PASSWORD, getOkapiUrl(), TEST_TENANT);
     List<String> paths = wireMockServer.getAllServeEvents().stream().map(e -> e.getRequest().getUrl()).collect(toList());
     assertThat(paths, hasItems("/authn/login", "/perms/users", "/authn/credentials", "/users", "/users?query=username==non_presented_user"));
   }
 
   @Test
+  void testOverrideDefaultSystemUser() {
+    var originalSystemUserParameters = securityManagerService.getSystemUserParameters(TEST_TENANT);
+
+    final var newOkapiUrl = "http://new-okapi-url";
+    securityManagerService.prepareOrUpdateSystemUser(SYSTEM_USER, SYSTEM_USER, newOkapiUrl, TEST_TENANT);
+    var updatedSystemUserParameters = securityManagerService.getSystemUserParameters(TEST_TENANT);
+
+    assertTrue(EqualsBuilder.reflectionEquals(originalSystemUserParameters, updatedSystemUserParameters, true, SystemUserParameters.class, true, "okapiUrl"));
+    assertThat(updatedSystemUserParameters.getOkapiUrl(), equalTo(newOkapiUrl));
+   }
+
+  @Test
   void testCreateNonExistedUser() {
-    credentialsRepository.save(buildSystemUserParameters(NON_EXISTED_USER));
-    securityManagerService.prepareSystemUser(NON_EXISTED_USER, PASSWORD, getOkapiUrl(), TEST_TENANT);
+    securityManagerService.prepareOrUpdateSystemUser(NON_EXISTED_USER, PASSWORD, getOkapiUrl(), TEST_TENANT);
     List<String> paths = wireMockServer.getAllServeEvents().stream().map(e -> e.getRequest().getUrl()).collect(toList());
     assertThat(paths, hasItems(  "/authn/login", "/perms/users", "/authn/credentials", "/users", "/users?query=username==non_existed_user"));
   }
 
   @Test
   void testCreateExistedUser() {
-    credentialsRepository.save(buildSystemUserParameters(EXISTED_USER));
-    securityManagerService.prepareSystemUser(EXISTED_USER, PASSWORD, getOkapiUrl(), TEST_TENANT);
+    securityManagerService.prepareOrUpdateSystemUser(EXISTED_USER, PASSWORD, getOkapiUrl(), TEST_TENANT);
     List<String> paths = wireMockServer.getAllServeEvents().stream().map(e -> e.getRequest().getUrl()).collect(toList());
     assertThat(paths, hasItems("/authn/login", "/perms/users/c78aa9ec-b7d3-4d53-9e43-20296f39b496/permissions?indexField=userId",
       "/users/c78aa9ec-b7d3-4d53-9e43-20296f39b496",
       "/users?query=username==existed_user"));
-  }
-
-  private SystemUserParameters buildSystemUserParameters(String username) {
-    SystemUserParameters systemUserParameters = new SystemUserParameters();
-    systemUserParameters.setId(UUID.randomUUID());
-    systemUserParameters.setUsername(username);
-    systemUserParameters.setTenantId(TEST_TENANT);
-    systemUserParameters.setOkapiUrl(getOkapiUrl());
-    systemUserParameters.setPassword(PASSWORD);
-    return systemUserParameters;
   }
 }


### PR DESCRIPTION
[MODRS-82](https://issues.folio.org/browse/MODRS-82) - Make system user updatable

## Purpose
System user should be updated each time when Tenant API is called

## Approach
Update system user properties each time when Tenant API is called

### TODOS and Open Questions
 <!-- OPTIONAL
 - [ ] Use GitHub checklists. When solved, check the box and explain the answer.
 -->

## Learning
 <!-- OPTIONAL
   Help out not only your reviewer, but also your fellow developer!
   Sometimes there are key pieces of information that you used to come up
   with your solution. Don't let all that hard work go to waste! A
   pull request is a *perfect opportunity to share the learning that
   you did. Add links to blog posts, patterns, libraries or addons used
   to solve this problem.
 -->

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
