### PR TITLE
MODRS-84 - Cannot mark item retrieved if there are more than 1 in retrieval queue

### DIFF
--- a/src/main/java/org/folio/rs/service/AccessionQueueService.java
+++ b/src/main/java/org/folio/rs/service/AccessionQueueService.java
@@ -242,12 +242,11 @@ public class AccessionQueueService {
   }
 
   public void setAccessionedByBarcode(String barcode) {
-    Optional<AccessionQueueRecord> accessionQueue = accessionQueueRepository.findOne(Specification.where(hasBarcode(barcode).and(notAccessioned())));
-    if (accessionQueue.isPresent()) {
-      saveAccessionQueueWithCurrentDate(accessionQueue.get());
-    } else {
+    List<AccessionQueueRecord> accessionQueues = accessionQueueRepository.findAll(Specification.where(hasBarcode(barcode).and(notAccessioned())));
+    if (accessionQueues.isEmpty()) {
       throw new EntityNotFoundException("Accession queue with item barcode " + barcode + " not found");
     }
+    accessionQueues.forEach(this::saveAccessionQueueWithCurrentDate);
   }
 
   /**

--- a/src/main/java/org/folio/rs/service/ReturnRetrievalQueueService.java
+++ b/src/main/java/org/folio/rs/service/ReturnRetrievalQueueService.java
@@ -5,10 +5,7 @@ import static org.folio.rs.util.MapperUtils.stringToUUIDSafe;
 import static org.folio.rs.util.RetrievalQueueRecordUtils.buildReturnRetrievalQueueRecord;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 import javax.persistence.EntityNotFoundException;
 import javax.persistence.criteria.Predicate;
@@ -82,11 +79,11 @@ public class ReturnRetrievalQueueService {
   }
 
   public void setRetrievedByBarcode(String barcode) {
-    Optional<ReturnRetrievalQueueRecord> retrievalQueueRecord = returnRetrievalQueueRepository.findOne(Specification.where(hasBarcode(barcode).and(notRetrievedSpecification())));
-    if (retrievalQueueRecord.isEmpty()) {
+    List<ReturnRetrievalQueueRecord> retrievalQueueRecords = returnRetrievalQueueRepository.findAll(Specification.where(hasBarcode(barcode).and(notRetrievedSpecification())));
+    if (retrievalQueueRecords.isEmpty()) {
       throw new EntityNotFoundException("Retrieval queue record with item barcode " + barcode + NOT_FOUND);
     }
-    saveRetrievalQueueWithCurrentDate(retrievalQueueRecord.get());
+    retrievalQueueRecords.forEach(this::saveRetrievalQueueWithCurrentDate);
   }
 
   public void processEventRequest(RequestEvent requestEvent) {


### PR DESCRIPTION
[MODRS-84](https://issues.folio.org/browse/MODRS-84) - Cannot mark item retrieved if there are more than 1 in retrieval queue

## Purpose

Since there is no way to delete items from the list of accessions or retrievals in the edge-dematic software, the dev team recommends addressing endpoints to mark the items accessioned or retrieved and they will be skipped up exchange with Dematic.

## Approach

Fixed errors

## Pre-Merge Checklist:

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.