### PR TITLE
FOLIO-3231 Use api-doc CI facility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ buildMvn {
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'OAS'
   apiDirectories = 'src/main/resources/swagger.api'
 


### PR DESCRIPTION
Adds the `doApiDoc` configuration to Jenkinsfile, which enables the [api-doc](https://dev.folio.org/guides/api-doc/) CI facility. This generates and publishes the API documentation during a merge to mainline and on release.

The `doApiLint` ([api-lint](https://dev.folio.org/guides/api-lint/)) was already configured.

The https://dev.folio.org/reference/api/#mod-remote-storage section of API documentation will be automatically reconfigured tomorrow:
https://dev.folio.org/reference/api/#explain-gather-config
