### PR TITLE
MODRS-94 - Improve remote storage accessioning process

### DIFF
--- a/src/main/java/org/folio/rs/service/AccessionQueueService.java
+++ b/src/main/java/org/folio/rs/service/AccessionQueueService.java
@@ -86,7 +86,8 @@ public class AccessionQueueService {
     log.info("Starting processing events...");
     events.forEach(event -> {
       log.info("Event received: {}", asJsonString(event));
-      if (DomainEventType.UPDATE == event.getType() && isEffectiveLocationChanged(event)) {
+      if (DomainEventType.CREATE == event.getType() ||
+          DomainEventType.UPDATE == event.getType() && isEffectiveLocationChanged(event)) {
         var item = event.getNewEntity();
         var systemUserParameters = securityManagerService.getSystemUserParameters(event.getTenant());
         FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext(

--- a/src/test/java/org/folio/rs/service/AccessionQueueServiceTest.java
+++ b/src/test/java/org/folio/rs/service/AccessionQueueServiceTest.java
@@ -41,6 +41,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
 import org.springframework.http.HttpStatus;
@@ -85,8 +87,9 @@ public class AccessionQueueServiceTest extends TestBase {
   }
 
 
-  @Test
-  void testItemUpdatingEventHandling() {
+  @ParameterizedTest
+  @EnumSource(value = DomainEventType.class, names = {"CREATE", "UPDATE"})
+  void testItemUpdatingEventHandling(DomainEventType domainEventType) {
 
     var mapping = new RemoteLocationConfigurationMapping()
       .folioLocationId(NEW_EFFECTIVE_LOCATION_ID)
@@ -112,46 +115,9 @@ public class AccessionQueueServiceTest extends TestBase {
         new ItemEffectiveCallNumberComponents().callNumber(CALL_NUMBER));
 
     var resourceBodyWithRemoteConfig = DomainEvent
-      .of(originalItem, newItem, DomainEventType.UPDATE, TEST_TENANT);
+      .of(domainEventType.equals(DomainEventType.UPDATE) ? originalItem : null, newItem, domainEventType, TEST_TENANT);
     var resourceBodyWithoutRemoteConfig = DomainEvent
-      .of(originalItem, newItemWithoutRemoteConfig, DomainEventType.UPDATE,
-        TEST_TENANT);
-
-    accessionQueueService.processAccessionQueueRecord(
-      Collections.singletonList(resourceBodyWithRemoteConfig));
-    accessionQueueService.processAccessionQueueRecord(
-      Collections.singletonList(resourceBodyWithoutRemoteConfig));
-
-    AccessionQueueRecord accessionQueueRecord = new AccessionQueueRecord();
-    accessionQueueRecord.setItemBarcode(BARCODE);
-    verifyCreatedAccessionQueueRecord(accessionQueueRepository.findAll(Example.of(accessionQueueRecord)).get(0));
-
-  }
-
-  @Test
-  void testItemCreationEventHandling() {
-
-    var mapping = new RemoteLocationConfigurationMapping()
-      .folioLocationId(NEW_EFFECTIVE_LOCATION_ID)
-      .configurationId(REMOTE_STORAGE_ID);
-    locationMappingsService.postRemoteLocationConfigurationMapping(mapping);
-
-    var newItem = new Item().effectiveLocationId(NEW_EFFECTIVE_LOCATION_ID)
-      .instanceId(INSTANCE_ID)
-      .barcode(BARCODE)
-      .effectiveCallNumberComponents(
-        new ItemEffectiveCallNumberComponents().callNumber(CALL_NUMBER));
-
-    var newItemWithoutRemoteConfig = new Item().effectiveLocationId(randomIdAsString())
-      .instanceId(INSTANCE_ID)
-      .barcode(BARCODE)
-      .effectiveCallNumberComponents(
-        new ItemEffectiveCallNumberComponents().callNumber(CALL_NUMBER));
-
-    var resourceBodyWithRemoteConfig = DomainEvent
-      .of(null, newItem, DomainEventType.CREATE, TEST_TENANT);
-    var resourceBodyWithoutRemoteConfig = DomainEvent
-      .of(null, newItemWithoutRemoteConfig, DomainEventType.CREATE,
+      .of(domainEventType.equals(DomainEventType.UPDATE) ? originalItem : null, newItemWithoutRemoteConfig, domainEventType,
         TEST_TENANT);
 
     accessionQueueService.processAccessionQueueRecord(


### PR DESCRIPTION
[MODRS-94](https://issues.folio.org/browse/MODRS-94) - Improve remote storage accessioning process

## Purpose
Improve remote storage accessioning process for data pushed from FOLIO to remote storage (Dematic EMS & StagingDirector). When an item record is added accessioning is not triggered because of the effective location on the holding record.  

## Approach
* Improved accession flow to process created items
* Updated unit tests

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [ ] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
