### PR TITLE
MODRS-135: Support holdings-storage 6.0, item-storage 10.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -12,7 +12,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "4.6 5.0"
+      "version": "4.6 5.0 6.0"
     },
     {
       "id": "identifier-types",
@@ -48,7 +48,7 @@
     },
     {
       "id": "item-storage",
-      "version": "8.8 9.0"
+      "version": "8.8 9.0 10.0"
     },
     {
       "id": "service-points",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-remote-storage only uses the holdings-storage and item-storage interfaces, it doesn't use the instance-storage interface.

mod-remote-storage is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-remote-storage.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json