### PR TITLE
MODRS-143: Upgrade dependencies fixing vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.5</version>
     <relativePath />
   </parent>
 
@@ -23,12 +23,14 @@
 
   <properties>
     <java.version>11</java.version>
-    <folio-spring-base-version>5.0.1</folio-spring-base-version>
+    <folio-spring-base-version>5.0.2</folio-spring-base-version>
     <openapi-generator.version>5.3.1</openapi-generator.version>
     <mapstruct.version>1.4.1.Final</mapstruct.version>
     <wiremock.version>2.27.2</wiremock.version>
-    <embedded.db.version>2.1.1</embedded.db.version>
-    <pubsub.client.version>2.0.0</pubsub.client.version>
+    <embedded.db.version>2.1.2</embedded.db.version>
+    <postgresql.version>42.5.0</postgresql.version>
+    <pubsub.client.version>2.7.0</pubsub.client.version>
+    <snakeyaml.version>1.33</snakeyaml.version>
     <sonar.exclusions>src/main/java/org/folio/rs/domain/**, src/main/java/org/folio/rs/client/AuthnClient.java,
       src/main/java/org/folio/rs/config/properties/**, src/main/java/org/folio/rs/service/PubSubService.java, src/main/java/org/folio/rs/error/PubSubException.java </sonar.exclusions>
     <remote-storage.yaml.file>src/main/resources/swagger.api/remote-storage.yaml</remote-storage.yaml.file>
@@ -119,6 +121,14 @@
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
     </dependency>
+
+    <!-- needed for org.folio.HttpStatus -->
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>util</artifactId>
+      <version>35.0.3</version>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -145,6 +155,12 @@
       <artifactId>embedded-database-spring-test</artifactId>
       <version>${embedded.db.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Upgrade postgresql JDBC client from 42.3.6 to 42.5.0 fixing SQL Injection:
https://nvd.nist.gov/vuln/detail/CVE-2022-31197
Note that only 42.5.* is officially supported for Java 11, 42.4.* and 42.3.* should no longer be used: 
https://jdbc.postgresql.org/security/#patches
https://jdbc.postgresql.org/download/#latest-versions

Upgrade folio-spring-base from 5.0.1 to 5.0.2.

Upgrading folio-spring-base indirectly upgrades commons-text from 1.9 to 1.10.0 fixing Arbitrary Code Execution: 
https://nvd.nist.gov/vuln/detail/CVE-2022-42889

Upgrading folio-spring-base indirectly upgrades jackson-databind from 2.13.3 to 2.13.4.2 fixing Denial of Service (DoS): 
https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrade spring-boot-starter-parent from 2.7.3 to 2.7.5.

Upgrading spring-boot-starter-parent indirectly upgrades kafka-clients from 3.1.1 to 3.1.2 fixing Memory Allocation with Excessive Size Value: 
https://nvd.nist.gov/vuln/detail/CVE-2022-34917

Upgrading spring-boot-starter-parent indirectly upgrades tomcat-embed-core from 9.0.65 to 9.0.68 fixing HTTP Request Smuggling: 
https://nvd.nist.gov/vuln/detail/CVE-2022-42252

Upgrade mod-pubsub-client from 2.0.0 to 2.7.0.

Upgrading mod-pubsub-client indirectly removes the unused dependency scala-library 2.13.1 that has a Remote Code Execution (RCE) vulnerability: 
https://nvd.nist.gov/vuln/detail/CVE-2022-36944

Upgrading mod-pubsub-client indirectly removes the unused runtime dependency commons-compress 1.10 that has a Denial of Service (DoS) vulnerabilities: 
https://nvd.nist.gov/vuln/detail/CVE-2018-11771
https://nvd.nist.gov/vuln/detail/CVE-2021-35515
https://nvd.nist.gov/vuln/detail/CVE-2021-35516
https://nvd.nist.gov/vuln/detail/CVE-2021-35517
https://nvd.nist.gov/vuln/detail/CVE-2021-36090

Upgrading mod-pubsub-client indirectly removes the unused dependency jackson-mapper-asl 1.9.1 that has an XML External Entity (XXE) Injection and two Denial of Service (DoS) vulnerabilities: 
https://nvd.nist.gov/vuln/detail/CVE-2019-10172
https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrading mod-pubsub-client indirectly removes the unused dependency javax.el 3.0.1-b11 with Improper Input Validation: 
https://nvd.nist.gov/vuln/detail/CVE-2021-28170

Upgrading mod-pubsub-client indirectly upgrades netty-handler from 4.1.79.Final to 4.1.84.Final fixing Improper Certificate Validation: 
https://app.snyk.io/vuln/SNYK-JAVA-IONETTY-1042268

Upgrade snakeyaml from 1.30 to 1.33 fixing Denial of Service (DoS) and Stack-based Buffer Overflow: 
https://nvd.nist.gov/vuln/detail/CVE-2022-25857
https://nvd.nist.gov/vuln/detail/CVE-2022-38749
https://nvd.nist.gov/vuln/detail/CVE-2022-38750
https://nvd.nist.gov/vuln/detail/CVE-2022-38751
https://nvd.nist.gov/vuln/detail/CVE-2022-38752

## Learning
Before releasing a module for a flower release upgrade all maven dependencies to the latest supported version to avoid any security vulnerabilities.