### PR TITLE
Modrs 148 (  /remote-storage/pub-sub-handlers/log-record-event returns 500 )

### DIFF
--- a/src/main/java/org/folio/rs/controller/PubSubEventController.java
+++ b/src/main/java/org/folio/rs/controller/PubSubEventController.java
@@ -50,10 +50,10 @@ public class PubSubEventController implements PubSubHandlersApi {
         } else {
           var payload = MAPPER.writeValueAsString(pubSubEvent.getPayload());
           log.info("pubSubHandlersLogRecordEventPost payload:{}",payload);
-          if (isPagedRequestCreated(logEventType, payload)) {
+          if (Objects.nonNull(pubSubEvent.getPayload()) && isPagedRequestCreated(logEventType, payload)) {
             requestEvent = MAPPER.readValue(payload, CreateRequestEvent.class);
           }
-          if (isRequestChangedToPaged(logEventType, payload)) {
+          if (Objects.nonNull(pubSubEvent.getPayload()) && isRequestChangedToPaged(logEventType, payload)) {
             requestEvent = MAPPER.readValue(payload, ChangeRequestEvent.class);
           }
           ofNullable(requestEvent).ifPresent(returnRetrievalQueueService::processEventRequest);

--- a/src/main/java/org/folio/rs/controller/PubSubEventController.java
+++ b/src/main/java/org/folio/rs/controller/PubSubEventController.java
@@ -40,12 +40,11 @@ public class PubSubEventController implements PubSubHandlersApi {
   @Override
   public ResponseEntity<String> pubSubHandlersLogRecordEventPost(@Valid PubSubEvent pubSubEvent) {
     if (Objects.nonNull(pubSubEvent)) {
-      log.info("pubSubHandlersLogRecordEventPost pubSubEvent:{}",pubSubEvent);
+      log.debug("pubSubHandlersLogRecordEventPost pubSubEvent:{}",pubSubEvent);
       RequestEvent requestEvent = null;
       try {
         var logEventType = pubSubEvent.getLogEventType();
         if (isItemCheckedId(logEventType)) {
-          log.info("pubSubHandlersLogRecordEventPost isItemCheckedId");
           returnItemService.returnItem(pubSubEvent.getItemBarcode());
         } else {
           var payload = MAPPER.writeValueAsString(pubSubEvent.getPayload());
@@ -68,7 +67,6 @@ public class PubSubEventController implements PubSubHandlersApi {
   }
 
   private boolean isRequestChangedToPaged(String logEventType, String payload) {
-    log.info("isRequestChangedToPaged payload:{}",payload);
     var dc = JsonPath.parse(payload);
     return isRequestChanged(logEventType) &&
       !Objects.equals(dc.read("$.requests.original.requestType"), dc.read("$.requests.updated.requestType"))
@@ -81,7 +79,6 @@ public class PubSubEventController implements PubSubHandlersApi {
   }
 
   private boolean isPagedRequestCreated(String logEventType, String payload) {
-    log.info("isPagedRequestCreated payload:{}",payload);
     var dc = JsonPath.parse(payload);
     return isRequestCreated(logEventType)
       && Objects.equals(PAGE.value(), dc.read("$.requests.created.requestType"));

--- a/src/main/java/org/folio/rs/controller/PubSubEventController.java
+++ b/src/main/java/org/folio/rs/controller/PubSubEventController.java
@@ -40,13 +40,16 @@ public class PubSubEventController implements PubSubHandlersApi {
   @Override
   public ResponseEntity<String> pubSubHandlersLogRecordEventPost(@Valid PubSubEvent pubSubEvent) {
     if (Objects.nonNull(pubSubEvent)) {
+      log.info("pubSubHandlersLogRecordEventPost pubSubEvent:{}",pubSubEvent);
       RequestEvent requestEvent = null;
       try {
         var logEventType = pubSubEvent.getLogEventType();
         if (isItemCheckedId(logEventType)) {
+          log.info("pubSubHandlersLogRecordEventPost isItemCheckedId");
           returnItemService.returnItem(pubSubEvent.getItemBarcode());
         } else {
           var payload = MAPPER.writeValueAsString(pubSubEvent.getPayload());
+          log.info("pubSubHandlersLogRecordEventPost payload:{}",payload);
           if (isPagedRequestCreated(logEventType, payload)) {
             requestEvent = MAPPER.readValue(payload, CreateRequestEvent.class);
           }
@@ -65,6 +68,7 @@ public class PubSubEventController implements PubSubHandlersApi {
   }
 
   private boolean isRequestChangedToPaged(String logEventType, String payload) {
+    log.info("isRequestChangedToPaged payload:{}",payload);
     var dc = JsonPath.parse(payload);
     return isRequestChanged(logEventType) &&
       !Objects.equals(dc.read("$.requests.original.requestType"), dc.read("$.requests.updated.requestType"))
@@ -77,6 +81,7 @@ public class PubSubEventController implements PubSubHandlersApi {
   }
 
   private boolean isPagedRequestCreated(String logEventType, String payload) {
+    log.info("isPagedRequestCreated payload:{}",payload);
     var dc = JsonPath.parse(payload);
     return isRequestCreated(logEventType)
       && Objects.equals(PAGE.value(), dc.read("$.requests.created.requestType"));

--- a/src/test/java/org/folio/rs/controller/PubSubEventControllerTest.java
+++ b/src/test/java/org/folio/rs/controller/PubSubEventControllerTest.java
@@ -121,7 +121,8 @@ public class PubSubEventControllerTest extends TestBase {
     log.info("=== Should not process event ===");
     var pubSubEvent = new PubSubEvent();
     pubSubEvent.setLogEventType(logEventType.value());
-    pubSubEvent.setPayload(buildBaseEventPayload());
+    pubSubEvent.setPayload(null);
+    pubSubEvent.setItemBarcode(ITEM_BARCODE);
 
     post(String.format(PUB_SUB_HANDLER_URL, okapiPort), MAPPER.writeValueAsString(pubSubEvent), String.class);
     Map<String, ReturnRetrievalQueueRecord> records = returnRetrievalQueueRepository.findAll().stream().collect(Collectors.toMap(ReturnRetrievalQueueRecord::getItemBarcode, identity()));


### PR DESCRIPTION
MODRS-148 ( https://issues.folio.org/browse/MODRS-148 )

## Purpose

-  /remote-storage/pub-sub-handlers/log-record-event returns 500

## Approach

-  null check added 
- test case updated

## Response 

![image](https://user-images.githubusercontent.com/103935659/209940618-f5ab6b9a-3841-4d71-891d-74e5b2195319.png)

![image](https://user-images.githubusercontent.com/103935659/209939949-e7db04d0-ca69-447a-ab55-d9f2be14100d.png)

[mod-pubsub.log](https://github.com/folio-org/mod-remote-storage/files/10318954/mod-pubsub.log)
