### PR TITLE
MODRS-157: Postgresql 42.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>2.27.2</wiremock.version>
     <embedded.db.version>2.2.0</embedded.db.version>
-    <postgresql.version>42.5.0</postgresql.version>
+    <postgresql.version>42.5.4</postgresql.version>
     <pubsub.client.version>2.7.0</pubsub.client.version>
     <snakeyaml.version>1.33</snakeyaml.version>
     <hazelcast.version>5.2.1</hazelcast.version>


### PR DESCRIPTION
https://issues.folio.org/browse/MODRS-157

Upgrade postgresql from 42.5.0 to 42.5.4 fixing Information Exposure and Socket Resource Leak:

https://nvd.nist.gov/vuln/detail/CVE-2022-41946
https://jdbc.postgresql.org/changelogs/2023-01-31-42.5.2-release/