### PR TITLE
Fix issue on the env when the module is failing with healthcheck /admin/health

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,13 @@
-## 1.8.0 Unreleased
+## 2.0.0 2023-02-23
+
+* [MODRS-119](https://issues.folio.org/browse/MODRS-119) - Logging improvement
+* [MODRS-140](https://issues.folio.org/browse/MODRS-140) - Logging improvement - Configuration
+* [MODRS-146](https://issues.folio.org/browse/MODRS-146) - Update to Java 17
+* [MODRS-147](https://issues.folio.org/browse/MODRS-147) - Update the module to Spring boot v3.0.0 and identify issues
+* [MODRS-148](https://issues.folio.org/browse/MODRS-148) - Endpoint /remote-storage/pub-sub-handlers/log-record-event returns 500
+* [MODRS-150](https://issues.folio.org/browse/MODRS-150) - Align the module with API breaking change
+* [MODRS-156](https://issues.folio.org/browse/MODRS-156) - Build failing due to dependency issue
+
 
 ## 1.7.0 Released
 This release contains module upgrades

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-remote-storage</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -28,7 +28,7 @@
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>2.27.2</wiremock.version>
     <embedded.db.version>2.2.0</embedded.db.version>
-    <postgresql.version>42.5.4</postgresql.version>
+    <postgresql.version>42.5.0</postgresql.version>
     <pubsub.client.version>2.7.0</pubsub.client.version>
     <snakeyaml.version>1.33</snakeyaml.version>
     <hazelcast.version>5.2.1</hazelcast.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-remote-storage</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -429,7 +429,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-remote-storage</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -28,7 +28,7 @@
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>2.27.2</wiremock.version>
     <embedded.db.version>2.2.0</embedded.db.version>
-    <postgresql.version>42.5.0</postgresql.version>
+    <postgresql.version>42.5.4</postgresql.version>
     <pubsub.client.version>2.7.0</pubsub.client.version>
     <snakeyaml.version>1.33</snakeyaml.version>
     <hazelcast.version>5.2.1</hazelcast.version>
@@ -429,7 +429,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v2.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ management:
     web:
       base-path: /admin
       exposure:
-        include: loggers
+        include: info,loggers,health
   endpoint:
     loggers:
       enabled: true


### PR DESCRIPTION
Just added the healthcheck endpoint to resolve the issue when the module is dropping on the environment
Note: The env is checking the /admin/health endpoint 

@gurleenkaurbp  Could you please take a look at this? Pls change it the way that you need but the "include: health" should be in place