### PR TITLE
Fix issue on the bugfest env when the module is failing with healthcheck /admin/health

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ management:
     web:
       base-path: /admin
       exposure:
-        include: loggers
+        include: info,loggers,health
   endpoint:
     loggers:
       enabled: true


### PR DESCRIPTION
Just added the healthcheck endpoint to resolve the issue when the module is dropping on the bugfest environment
Note: The env is checking the /admin/health endpoint

@gurleenkaurbp  Could you please take a look at this? Pls change it the way that you need but the "include: health" should be in place