### PR TITLE
MODRS-161: Spring Boot 3.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.5</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
https://issues.folio.org/browse/MODRS-161

Upgrade spring-boot-starter-parent from 3.0.2 to 3.0.5.