### PR TITLE
MODRS-185: Spring Boot 3.1.5, Kafka 3.5.1, mod-pubsub-client 2.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath />
   </parent>
 
@@ -30,10 +30,14 @@
     <wiremock.version>2.27.2</wiremock.version>
     <embedded.db.version>2.2.0</embedded.db.version>
     <postgresql.version>42.6.0</postgresql.version>
-    <pubsub.client.version>2.9.1</pubsub.client.version>
+    <pubsub.client.version>2.11.2</pubsub.client.version>
     <snakeyaml.version>2.2</snakeyaml.version>
     <hazelcast.version>5.3.2</hazelcast.version>
     <folio-util.version>35.1.0</folio-util.version>
+
+    <!-- bump kafka.version to fix snappy-java vulnerabilities;
+         remove <kafka.version> when using spring-boot-starter-parent >= 3.2 -->
+    <kafka.version>3.5.1</kafka.version>
 
     <maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>


### PR DESCRIPTION
https://issues.folio.org/browse/MODRS-185

Upgrade spring-boot-starter-parent from 3.1.4 to 3.1.5. This indirectly upgrades tomcat-embed-core from 10.1.13 to 10.1.15 fixing Denial of Service (DoS) and Improper Input Validation and Incomplete Cleanup:
https://nvd.nist.gov/vuln/detail/CVE-2023-44487
https://nvd.nist.gov/vuln/detail/CVE-2023-45648
https://nvd.nist.gov/vuln/detail/CVE-2023-42795

Upgrade Kafka from 3.4.1 to 3.5.1. This indirectly upgrades snappy-java from 1.1.8.4 to 1.1.10.1 fixing Allocation of Resources Without Limits or Throttling, Denial of Service (DoS), Integer Overflow or Wraparound:
https://nvd.nist.gov/vuln/detail/CVE-2023-43642
https://nvd.nist.gov/vuln/detail/CVE-2023-34455
https://nvd.nist.gov/vuln/detail/CVE-2023-34454
https://nvd.nist.gov/vuln/detail/CVE-2023-34453

Upgrade mod-pubsub-client from 2.9.1 to 2.12.2. This indirectly upgrades netty-codec-http2 from 4.1.97.Final to 4.1.100.Final fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2023-44487