### PR TITLE
MODRS-19: hazelcast 5.3.6 fixing org.json:json OOM CVE-2023-5072

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <postgresql.version>42.6.0</postgresql.version>
     <pubsub.client.version>2.11.2</pubsub.client.version>
     <snakeyaml.version>2.2</snakeyaml.version>
-    <hazelcast.version>5.3.2</hazelcast.version>
+    <hazelcast.version>5.3.6</hazelcast.version>
     <folio-util.version>35.1.0</folio-util.version>
 
     <!-- bump kafka.version to fix snappy-java vulnerabilities;


### PR DESCRIPTION
Upgrade hazelcast from 5.3.2 to >= 5.3.5.

hazelcast 5.3.2 contains relocated org.json:json:20230227:
https://github.com/hazelcast/hazelcast/blob/v5.3.2/hazelcast/pom.xml#L515
https://github.com/hazelcast/hazelcast/blob/v5.3.2/hazelcast/pom.xml#L191-L198

org.json:json:20230227 is vulnerable, a bug in the parser means that an input string of modest size can lead to indefinite amounts of memory being used:
https://nvd.nist.gov/vuln/detail/CVE-2023-5072

hazelcast 5.3.5 with everit-json-schema:1.14.3 with the fix has been released:
https://github.com/hazelcast/hazelcast/commits/v5.3.5

To prevent out of memory (OOM) issues and attacks we upgrade hazelcast.