### PR TITLE
MODRS-186: Make system user creation optional

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * [MODRS-185](https://issues.folio.org/browse/MODRS-185) - Spring Boot 3.1.5, Kafka 3.5.1, mod-pubsub-client 2.12.2
 * [MODRS-190](https://issues.folio.org/browse/MODRS-190) - hazelcast 5.3.6 fixing org.json:json OOM CVE-2023-5072
+* [MODRS-186](https://issues.folio.org/browse/MODRS-186) - Make system user creation optional
 
 ## 3.0.0 2023-10-12
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ API provides the following URL to mark item as missing:
 | KAFKA_SSL_TRUSTSTORE_PASSWORD |             -             | The password for the Kafka trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. |
 | SYSTEM\_USER\_NAME            |        system-user        | Username of the system user.                                                                                                                               |
 | SYSTEM\_USER\_PASSWORD        |             -             | Password of the system user.                                                                                                                               |
+| SYSTEM\_USER\_ENABLED         |           true            | Defines if system user must be created at service tenant initialization or used for egress service requests                                                |
 | OKAPI_URL                     |     http://okapi:9130     | OKAPI URL used to login system user, required                                                                                                              |
 | ENV                           |           folio           | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed     |
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-remote-storage</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.0.1-modrs-186</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -24,7 +24,7 @@
   <properties>
     <java.version>17</java.version>
     <folio-spring-base.version>7.2.0</folio-spring-base.version>
-    <folio-spring-system-user.version>7.2.0</folio-spring-system-user.version>
+    <folio-spring-system-user.version>7.3.0-folspringb-128</folio-spring-system-user.version>
     <openapi-generator.version>6.6.0</openapi-generator.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <wiremock.version>2.27.2</wiremock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-remote-storage</artifactId>
-  <version>3.0.1-modrs-186</version>
+  <version>3.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -24,7 +24,7 @@
   <properties>
     <java.version>17</java.version>
     <folio-spring-base.version>7.2.0</folio-spring-base.version>
-    <folio-spring-system-user.version>7.3.0-folspringb-128</folio-spring-system-user.version>
+    <folio-spring-system-user.version>7.3.0-SNAPSHOT</folio-spring-system-user.version>
     <openapi-generator.version>6.6.0</openapi-generator.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <wiremock.version>2.27.2</wiremock.version>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,7 @@ server.port: 8081
 folio.tenant.validation.enabled: false
 folio:
   system-user:
+    enabled: ${SYSTEM_USER_ENABLED:true}
     username: ${SYSTEM_USER_NAME:system-user}
     password: ${SYSTEM_USER_PASSWORD}
     permissionsFilePath: permissions/system-user-permissions.csv

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,5 +34,6 @@ server.port: 8081
 folio.tenant.validation.enabled: true
 folio:
   system-user:
+    enabled: true
     username: ${SYSTEM_USER_NAME:system-user}
     password: ${SYSTEM_USER_PASSWORD:password}


### PR DESCRIPTION
### Purpose
To support a proof of concept for improved provisioning and management of system users, implement the ability to disable the creation, management, and use of system users in modules. [MODRS-186 ](https://issues.folio.org/browse/MODRS-186 )
The branch was actualized and prepared to merge in master branch in scope of [MODROLESKC-24](https://issues.folio.org/browse/MODROLESKC-24)
### Approach
- Add `SYSTEM_USER_ENABLED` configuration property to control system user creation/usage
- Remove redundant classes (they must be deleted with migration to the `folio-spring-system-user`)

### Changes Checklist
- [ ] **API Changes**: List any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Specify any database schema changes and their impact.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Note added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **NEWS**: Ensure that the `NEWS` file is updated with relevant information about the changes made in this pull request.

### Related Issues
_List any Jira issues related to this pull request._

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
