### PR TITLE
MODRS-233: Fix master branch from 3.4.1-SNAPSHOT to 3.5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-remote-storage</artifactId>
-  <version>3.4.1-SNAPSHOT</version>
+  <version>3.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODRS-233

The reference environments like https://folio-snapshot.dev.folio.org/ should be built using the latest master branch version of all repositories.

This is implemented by using the latest SNAPSHOT version.

This only works if

* the master branch uses the next minor version: 3.5.0-SNAPSHOT, and
* the b3.4 branch uses the next patch version: 3.4.1-SNAPSHOT.

See 
* https://folio-project.slack.com/archives/C210RP0T1/p1741274898916269
* https://folio-project.slack.com/archives/C210RP0T1/p1741816909580189 
* https://dev.folio.org/guidelines/release-procedures/#maven-based-modules

Currently the master branch incorrectly uses 3.4.1-SNAPSHOT so that a commit to the b3.4 branch ends up in there reference environment. This is not wanted.

Solution: Change the master branch version to 3.5.0-SNAPSHOT.

## Purpose
Fix master branch version.

## Approach
Bump master branch version from 3.4.1-SNAPSHOT to 3.5.0-SNAPSHOT.

## Learning
Follow the release procedures:

https://dev.folio.org/guidelines/release-procedures/#maven-based-modules

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] Check logging