### PR TITLE
MODRS-223: Add database index for item_notes.item_id

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -11,4 +11,5 @@
   <include file="changes/location_mappings_update_schema.xml" relativeToChangelogFile="true"/>
   <include file="changes/location_mappings_update_schema_tech_debt.xml" relativeToChangelogFile="true"/>
   <include file="changes/add_item_notes_table.xml" relativeToChangelogFile="true"/>
+  <include file="changes/add_item_notes_item_id_idx.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/add_item_notes_item_id_idx.sql
+++ b/src/main/resources/db/changelog/changes/add_item_notes_item_id_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS item_notes_item_id_idx ON item_notes (item_id);

--- a/src/main/resources/db/changelog/changes/add_item_notes_item_id_idx.xml
+++ b/src/main/resources/db/changelog/changes/add_item_notes_item_id_idx.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet author="FOLIO" id="MODRS_223_add_item_notes_item_id_idx">
+    <sqlFile dbms="postgresql"
+             path="add_item_notes_item_id_idx.sql"
+             relativeToChangelogFile="true"
+             splitStatements="false"/>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODRS-223

## Purpose
Make queries by item_notes.item_id faster.

## Approach
Add database index for item_notes.item_id

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.
   - [x] Check logging